### PR TITLE
Updates Essentials minimum version dependency to 1.8.0

### DIFF
--- a/epi-display-lg/LgDisplayControllerFactory.cs
+++ b/epi-display-lg/LgDisplayControllerFactory.cs
@@ -10,7 +10,7 @@ namespace Epi.Display.Lg
         {
             TypeNames = new List<string> {"lgDisplay", "lgPlugin", "lg"};
 
-            MinimumEssentialsFrameworkVersion = "1.6.8";
+            MinimumEssentialsFrameworkVersion = "1.8.0";
         }
 
         #region Overrides of EssentialsDeviceFactory<LgDisplayController>

--- a/epi-display-lg/LgDisplayDevice.cs
+++ b/epi-display-lg/LgDisplayDevice.cs
@@ -10,7 +10,7 @@ using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Bridges;
 using PepperDash.Essentials.Core.Routing;
 
-using PepperDash_Essentials_Core.Queues;
+using PepperDash.Essentials.Core.Queues;
 
 namespace Epi.Display.Lg
 {

--- a/epi-display-lg/Properties/AssemblyInfo.cs
+++ b/epi-display-lg/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Epi-Display-Lg")]
 [assembly: AssemblyCopyright("Copyright ©  2019")]
-[assembly: AssemblyVersion("1.0.0.*")]
+[assembly: AssemblyVersion("0.0.0.*")]
 [assembly: AssemblyInformationalVersion("0.0.0-buildtype-build#")]
 [assembly: Crestron.SimplSharp.Reflection.AssemblyInformationalVersion("0.0.0-buildtype-build#")]
 

--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,3 @@
 <packages>
-  <package id="PepperDashEssentials" version="1.6.8" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
+  <package id="PepperDashEssentials" version="1.8.0" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
 </packages>


### PR DESCRIPTION
Resolves issue with missing method exception due to namespace change in 1.8.0 of Essentials.

Updates version dependency to 1.8.0 and specifies new namespace for `PepperDash.Essentials.Core.Queues`.