### PR TITLE
Fix _inputSwitchPending never cleared on action() exception in ExecuteSwitch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,4 @@ MigrationBackup/
 *.projectinfo
 /output/epi-display-lg.4Series.1.0.0-local.cplz
 /src/._epi-display-lg.4Series.csproj
+.nuget/

--- a/src/LgDisplayBridgeJoinMap.cs
+++ b/src/LgDisplayBridgeJoinMap.cs
@@ -54,6 +54,34 @@ namespace Epi.Display.Lg
         //        JoinType = eJoinType.Digital
         //    });
 
+        [JoinName("IsCoolingDown")]
+        public JoinDataComplete IsCoolingDown = new JoinDataComplete(
+           new JoinData
+           {
+               JoinNumber = 4,
+               JoinSpan = 1
+           },
+           new JoinMetadata
+           {
+               Description = "Display is Cooling Down",
+               JoinCapabilities = eJoinCapabilities.ToSIMPL,
+               JoinType = eJoinType.Digital
+           });
+
+        [JoinName("IsWarmingUp")]
+        public JoinDataComplete IsWarmingUp = new JoinDataComplete(
+           new JoinData
+           {
+               JoinNumber = 5,
+               JoinSpan = 1
+           },
+           new JoinMetadata
+           {
+               Description = "Display is Warming Up",
+               JoinCapabilities = eJoinCapabilities.ToSIMPL,
+               JoinType = eJoinType.Digital
+           });
+
         //[JoinName("InputSelectOffset")]
         //public JoinDataComplete InputSelectOffset = new JoinDataComplete(
         //    new JoinData

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -34,7 +34,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         private bool _isMuted;
         private bool _isSerialComm;
         private bool _isWarmingUp;
-        private bool _lastCommandSentWasVolume;
+        private string _lastCommandPrefix;
         private int _lastVolumeSent;
         private bool _powerIsOn;
         private bool _videoIsMuted;
@@ -750,15 +750,14 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// <param name="s"></param>
         public void SendData(string s)
         {
-            if (_lastCommandSentWasVolume)
+            var commandPrefix = s.Length >= 2 ? s.Substring(0, 2) : string.Empty;
+
+            if (_lastCommandPrefix == "kf" && commandPrefix != "kf")
             {
-                if (s[1] != 'f')
-                {
-                    CrestronEnvironment.Sleep(100);
-                }
+                CrestronEnvironment.Sleep(100);
             }
 
-            _lastCommandSentWasVolume = s[1] == 'f';
+            _lastCommandPrefix = commandPrefix;
 
             Communication.SendText(s + "\x0D");
         }
@@ -787,7 +786,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
                 if (port.Selector is Action action)
                 {
-                    this.LogInformation("***** TESTING ***** SetInput: action is {0}", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
+                    this.LogVerbose("SetInput: {0}", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                     ExecuteSwitch(action);
                 }
                 else
@@ -876,7 +875,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public void InputGet()
         {
-            SendData(string.Format("kb {0} FF", Id));
+            SendData(string.Format("xb {0} FF", Id));
         }
 
         /// <summary>
@@ -885,46 +884,43 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// <param name="selector"></param>
         public override void ExecuteSwitch(object selector)
         {
-            this.LogInformation("***** TESTING ***** ExecuteSwitch: called with selector of type {0}", selector?.GetType().Name ?? "NULL");
-
             if (!(selector is Action action))
             {
-                this.LogInformation("***** TESTING ***** ExecuteSwitch: selector is not an Action. Type: {0}", selector?.GetType().Name ?? "NULL");
+                this.LogVerbose("ExecuteSwitch: selector is not an Action. Type: {0}", selector?.GetType().Name ?? "NULL");
                 return;
             }
 
-            this.LogInformation("***** TESTING ***** ExecuteSwitch: action is {0}", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
+            this.LogVerbose("ExecuteSwitch: preparing to execute {0}", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
 
             if (PowerIsOn)
             {
-                this.LogInformation("***** TESTING ***** Power is already on. Executing action.");
                 action();
             }
             else if (IsCoolingDown)
             {
-                this.LogInformation("***** TESTING ***** Device is cooling down. Powering on and executing action after cooldown.");
+                this.LogVerbose("ExecuteSwitch: Device is cooling down. Powering on and executing {0} after cooldown.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    this.LogInformation("***** TESTING ***** Cooldown complete. Powering on.");
                     CrestronEnvironment.Sleep((int)CooldownTime);
+
+                    this.LogVerbose("ExecuteSwitch: Cooldown complete. Powering on.");
                     PowerOn();
-                    this.LogInformation("***** TESTING ***** Warmup time starting.");
-                    CrestronEnvironment.Sleep((int)WarmupTime);
-                    this.LogInformation("***** TESTING ***** Warmup complete. Executing action after delay.");
-                    CrestronEnvironment.Sleep(1000);
+
+                    CrestronEnvironment.Sleep((int)WarmupTime + 1000); // warmup time + 1000 for input switching delay                    
+
+                    this.LogVerbose("ExecuteSwitch: Warmup complete. Executing {0}.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                     action();
                 });
             }
             else
             {
-                this.LogInformation("***** TESTING ***** Power is off. Powering on and executing action after warmup.");
+                this.LogVerbose("ExecuteSwitch: Power is off. Powering on and executing {0} after warmup.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                 PowerOn();
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    this.LogInformation("***** TESTING ***** Warmup time starting.");
-                    CrestronEnvironment.Sleep((int)WarmupTime);
-                    this.LogInformation("***** TESTING ***** Warmup complete. Executing action after delay.");
-                    CrestronEnvironment.Sleep(1000);
+                    CrestronEnvironment.Sleep((int)WarmupTime + 1000); // warmup time + 1000 for input switching delay                    
+
+                    this.LogVerbose("ExecuteSwitch: Warmup complete. Executing {0}.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                     action();
                 });
             }
@@ -936,20 +932,15 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public override void PowerOn()
         {
-            // if (PowerIsOn)
-            //     return;
-
-            this.LogInformation("***** TESTING ***** PowerOn called. IsWarmingUp: {0}, IsCoolingDown: {1}", IsWarmingUp, IsCoolingDown);
-
             if (IsCoolingDown)
             {
-                this.LogInformation("***** TESTING ***** Device is cooling down. Powering on after cooldown completes.");
-
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    this.LogInformation("***** TESTING ***** Cooldown complete. Powering on.");
+                    this.LogVerbose("PowerOn: Device is cooling down. Powering on after cooldown completes.");
+
                     CrestronEnvironment.Sleep((int)CooldownTime);
-                    this.LogInformation("***** TESTING ***** Powering on.");
+
+                    this.LogVerbose("PowerOn: Cooldown complete. Powering on.");
                     SendPowerOn();
                 });
                 return;
@@ -963,18 +954,15 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public override void PowerOff()
         {
-            // if (!PowerIsOn)
-            //     return;
-
-            this.LogInformation("***** TESTING ***** PowerOff called. IsWarmingUp: {0}, IsCoolingDown: {1}", IsWarmingUp, IsCoolingDown);
-
             if (IsWarmingUp)
             {
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    this.LogInformation("***** TESTING ***** Device is warming up. Powering off after warmup completes.");
+                    this.LogVerbose("PowerOff: Device is warming up. Powering off after warmup completes.");
+
                     CrestronEnvironment.Sleep((int)WarmupTime);
-                    this.LogInformation("***** TESTING ***** Warmup complete. Powering off.");
+
+                    this.LogVerbose("PowerOff: Warmup complete. Powering off.");
                     SendPowerOff();
                 });
                 return;
@@ -985,8 +973,6 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         private void SendPowerOn()
         {
-            this.LogInformation("***** TESTING ***** SendPowerOn called.");
-
             if (_isSerialComm || _overrideWol)
             {
                 SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "1" : "01"));
@@ -998,8 +984,6 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         private void SendPowerOff()
         {
-            this.LogInformation("***** TESTING ***** SendPowerOff called.");
-
             SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "0" : "00"));
 
             IsWarmingUp = false;

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -854,7 +854,8 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                     PowerOn();
                     this.LogInformation("***** TESTING ***** Warmup time starting.");
                     CrestronEnvironment.Sleep((int)WarmupTime);
-                    this.LogInformation("***** TESTING ***** Warmup complete. Executing action.");
+                    this.LogInformation("***** TESTING ***** Warmup complete. Executing action after delay.");
+                    CrestronEnvironment.Sleep(1000);
                     action();
                 });
             }
@@ -866,7 +867,8 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 {
                     this.LogInformation("***** TESTING ***** Warmup time starting.");
                     CrestronEnvironment.Sleep((int)WarmupTime);
-                    this.LogInformation("***** TESTING ***** Warmup complete. Executing action.");
+                    this.LogInformation("***** TESTING ***** Warmup complete. Executing action after delay.");
+                    CrestronEnvironment.Sleep(1000);
                     action();
                 });
             }
@@ -941,7 +943,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         private void SendPowerOff()
         {
             this.LogInformation("***** TESTING ***** SendPowerOff called.");
-            
+
             SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "0" : "00"));
 
             IsWarmingUp = false;

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -98,8 +98,15 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
                 if (_powerIsOn)
                 {
-                    IsWarmingUp = true;
+                    if (CooldownTimer != null)
+                    {
+                        CooldownTimer.Stop();
+                        CooldownTimer.Dispose();
+                        CooldownTimer = null;
+                    }
+                    IsCoolingDown = false;
 
+                    IsWarmingUp = true;
                     WarmupTimer = new CTimer(o =>
                     {
                         IsWarmingUp = false;
@@ -107,8 +114,15 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 }
                 else
                 {
-                    IsCoolingDown = true;
+                    if (WarmupTimer != null)
+                    {
+                        WarmupTimer.Stop();
+                        WarmupTimer.Dispose();
+                        WarmupTimer = null;
+                    }
+                    IsWarmingUp = false;
 
+                    IsCoolingDown = true;
                     CooldownTimer = new CTimer(o =>
                     {
                         IsCoolingDown = false;

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -836,42 +836,35 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// <param name="selector"></param>
         public override void ExecuteSwitch(object selector)
         {
-            //if (!(selector is Action))
-            //    Debug.LogDebug(this, "WARNING: ExecuteSwitch cannot handle type {0}", selector.GetType());
+            if (!(selector is Action action))
+            {
+                Debug.LogError(this, "ExecuteSwitch: selector is not an Action! Type: {0}",
+                    selector?.GetType().Name ?? "NULL");
+                return;
+            }
 
             if (PowerIsOn)
             {
-                var action = selector as Action;
-                if (action != null)
-                {
-                    action();
-                }
-                else
-                {
-                    Debug.LogError(this, "ExecuteSwitch: selector is not an Action! Type: {0}", selector?.GetType().Name ?? "NULL");
-                }
+                action();
             }
-            else // if power is off, wait until we get on FB to send it. 
+            else if (IsCoolingDown)
             {
-                // One-time event handler to wait for power on before executing switch
-                EventHandler<FeedbackEventArgs> handler = null; // necessary to allow reference inside lambda to handler
-                handler = (o, a) =>
+                CrestronInvoke.BeginInvoke((o) =>
                 {
-                    if (_isWarmingUp)
-                    {
-                        return;
-                    }
-
-                    IsWarmingUpFeedback.OutputChange -= handler;
-
-                    var action = selector as Action;
-                    if (action != null)
-                    {
-                        action();
-                    }
-                };
-                IsWarmingUpFeedback.OutputChange += handler; // attach and wait for on FB
+                    CrestronEnvironment.Sleep((int)CooldownTime);
+                    PowerOn();
+                    CrestronEnvironment.Sleep((int)WarmupTime);
+                    action();
+                });
+            }
+            else
+            {
                 PowerOn();
+                CrestronInvoke.BeginInvoke((o) =>
+                {
+                    CrestronEnvironment.Sleep((int)WarmupTime);
+                    action();
+                });
             }
         }
 
@@ -1105,6 +1098,10 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
             CrestronInvoke.BeginInvoke((o) =>
                 {
                     PowerGet();
+
+                    if (IsWarmingUp || IsCoolingDown)
+                        return;
+
                     CrestronEnvironment.Sleep(1500);
                     InputGet();
                     CrestronEnvironment.Sleep(1500);

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -344,6 +344,11 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
             }
         }
 
+        public void VideoMuteGet()
+        {
+            SendData(string.Format("kd {0} FF", Id));
+        }
+
         #endregion
 
         #region IBridgeAdvanced Members
@@ -609,10 +614,57 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
             ReceiveQueue.Enqueue(new ProcessStringMessage(args.Text, ProcessResponse));
         }
 
+        private void PollAfterNgResponse(string ngCommand)
+        {
+            switch (ngCommand)
+            {
+                case "a":
+                    {
+                        PowerGet();
+                        break;
+                    }
+                case "b":
+                    {
+                        if (!PowerIsOn) return;
+
+                        InputGet();
+                        break;
+                    }
+                case "f":
+                    {
+                        if (!PowerIsOn) return;
+
+                        VolumeGet();
+                        break;
+                    }
+                case "e":
+                    {
+                        if (!PowerIsOn) return;
+
+                        MuteGet();
+                        break;
+                    }
+                case "d":
+                    {
+                        if (!PowerIsOn) return;
+
+                        VideoMuteGet();
+                        break;
+                    }
+            }
+        }
+
         private void ProcessResponse(string s)
         {
             if (s.ToLower().Contains("ng"))
             {
+                var ngData = s.Trim().Split(' ');
+                var ngCommand = ngData.Length >= 1 ? ngData[0] : string.Empty;
+
+                Debug.LogVerbose(this, "NG response received for command '{0}': {1}", ngCommand, s);
+
+                PollAfterNgResponse(ngCommand);
+
                 return;
             }
 
@@ -720,7 +772,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
             {
                 if (value <= 0 || value > InputPorts.Count)
                 {
-                    Debug.LogError(this, "SetInput: Value {0} is out of range (1-{1})", value, InputPorts.Count);
+                    this.LogError("SetInput: Value {0} is out of range (1-{1})", value, InputPorts.Count);
                     return;
                 }
 
@@ -729,17 +781,18 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 var port = GetInputPort(portIndex);
                 if (port == null)
                 {
-                    Debug.LogError(this, "SetInput: Port at index {0} is null", portIndex);
+                    this.LogError("SetInput: Port at index {0} is null", portIndex);
                     return;
                 }
 
                 if (port.Selector is Action action)
                 {
+                    this.LogInformation("***** TESTING ***** SetInput: action is {0}", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                     ExecuteSwitch(action);
                 }
                 else
                 {
-                    Debug.LogError(this, "SetInput: Port selector is not an Action! Type: {0}",
+                    this.LogError("SetInput: Port selector is not an Action! Type: {0}",
                         port.Selector?.GetType().Name ?? "NULL");
                 }
             }
@@ -757,7 +810,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             foreach (var inputPort in InputPorts)
             {
-                Debug.LogVerbose(this, "ListRoutingInputPorts: key-'{0}', connectionType-'{1}', feedbackMatchObject-'{2}'",
+                this.LogVerbose("ListRoutingInputPorts: key-'{0}', connectionType-'{1}', feedbackMatchObject-'{2}'",
                     inputPort.Key, inputPort.ConnectionType, inputPort.FeedbackMatchObject);
             }
         }
@@ -832,12 +885,15 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// <param name="selector"></param>
         public override void ExecuteSwitch(object selector)
         {
-            this.LogInformation("***** TESTING ***** ExecuteSwitch called with selector of type {0}", selector?.GetType().Name ?? "NULL");
+            this.LogInformation("***** TESTING ***** ExecuteSwitch: called with selector of type {0}", selector?.GetType().Name ?? "NULL");
 
             if (!(selector is Action action))
             {
+                this.LogInformation("***** TESTING ***** ExecuteSwitch: selector is not an Action. Type: {0}", selector?.GetType().Name ?? "NULL");
                 return;
             }
+
+            this.LogInformation("***** TESTING ***** ExecuteSwitch: action is {0}", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
 
             if (PowerIsOn)
             {

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -980,42 +980,25 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// <param name="s">response from device</param>
         public void UpdateInputFb(string s)
         {
-            var newInput = InputPorts.FirstOrDefault(i => i.FeedbackMatchObject.Equals(s.ToLower()));
+            var normalizedInput = s.ToLower();
+
+            var newInput = InputPorts.FirstOrDefault(i => i.FeedbackMatchObject.Equals(normalizedInput));
             if (newInput != null && newInput != _currentInputPort)
             {
                 _currentInputPort = newInput;
                 CurrentInputFeedback.FireUpdate();
-                var key = newInput.Key;
-                switch (key)
-                {
-                    case "hdmiIn1":
-                        InputNumber = 1;
-                        break;
-                    case "hdmiIn2":
-                        InputNumber = 2;
-                        break;
-                    case "hdmiIn3":
-                        InputNumber = 3;
-                        break;
-                    case "hdmiIn4":
-                        InputNumber = 4;
-                        break;
-                    case "displayPortIn":
-                        InputNumber = 5;
-                        break;
-                }
+                InputNumber = InputPorts.ToList().IndexOf(newInput) + 1;
             }
 
-            if (Inputs.Items.ContainsKey(s))
+            if (Inputs.Items.ContainsKey(normalizedInput))
             {
-
                 foreach (var item in Inputs.Items)
                 {
-                    item.Value.IsSelected = item.Key.Equals(s);
+                    item.Value.IsSelected = item.Key.Equals(normalizedInput);
                 }
-            }
 
-            Inputs.CurrentItem = s;
+                Inputs.CurrentItem = normalizedInput;
+            }
         }
 
         /// <summary>

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -123,13 +123,13 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             get
             {
-                this.LogVerbose("IsWarmingUp get: {0}", _isWarmingUp);
+                this.LogInformation("[TESTING] IsWarmingUp get: {0}", _isWarmingUp);
                 return _isWarmingUp;
             }
             set
             {
                 _isWarmingUp = value;
-                this.LogVerbose("IsWarmingUp set: {0}", _isWarmingUp);
+                this.LogInformation("[TESTING] IsWarmingUp set: {0}", _isWarmingUp);
 
                 IsWarmingUpFeedback.FireUpdate();
             }
@@ -139,13 +139,13 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             get
             {
-                this.LogVerbose("IsCoolingDown get: {0}", _isCoolingDown);
+                this.LogInformation("[TESTING] IsCoolingDown get: {0}", _isCoolingDown);
                 return _isCoolingDown;
             }
             set
             {
                 _isCoolingDown = value;
-                this.LogVerbose("IsCoolingDown set: {0}", _isCoolingDown);
+                this.LogInformation("[TESTING] IsCoolingDown set: {0}", _isCoolingDown);
 
                 IsCoolingDownFeedback.FireUpdate();
             }
@@ -836,33 +836,41 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// <param name="selector"></param>
         public override void ExecuteSwitch(object selector)
         {
+            this.LogInformation("[TESTING] ExecuteSwitch called with selector of type {0}", selector?.GetType().Name ?? "NULL");
+
             if (!(selector is Action action))
             {
-                Debug.LogError(this, "ExecuteSwitch: selector is not an Action! Type: {0}",
-                    selector?.GetType().Name ?? "NULL");
                 return;
             }
 
             if (PowerIsOn)
             {
+                this.LogInformation("[TESTING] Power is already on. Executing action.");
                 action();
             }
             else if (IsCoolingDown)
             {
+                this.LogInformation("[TESTING] Device is cooling down. Powering on and executing action after cooldown.");
                 CrestronInvoke.BeginInvoke((o) =>
                 {
+                    this.LogInformation("[TESTING] Cooldown complete. Powering on.");
                     CrestronEnvironment.Sleep((int)CooldownTime);
                     PowerOn();
+                    this.LogInformation("[TESTING] Warmup time starting.");
                     CrestronEnvironment.Sleep((int)WarmupTime);
+                    this.LogInformation("[TESTING] Warmup complete. Executing action.");
                     action();
                 });
             }
             else
             {
+                this.LogInformation("[TESTING] Power is off. Powering on and executing action after warmup.");
                 PowerOn();
                 CrestronInvoke.BeginInvoke((o) =>
                 {
+                    this.LogInformation("[TESTING] Warmup time starting.");
                     CrestronEnvironment.Sleep((int)WarmupTime);
+                    this.LogInformation("[TESTING] Warmup complete. Executing action.");
                     action();
                 });
             }

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -665,45 +665,41 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         private void ProcessResponse(string s)
         {
-            if (s.ToLower().Contains("ng"))
-            {
-                var ngData = s.Trim().Split(' ');
-                var ngCommand = ngData.Length >= 1 ? ngData[0] : string.Empty;
-
-                Debug.LogVerbose(this, "NG response received for command '{0}': {1}", ngCommand, s);
-
-                PollAfterNgResponse(ngCommand);
-
-                return;
-            }
-
-            //Example response for feedback of power.off from device: "a 1 OK01x"
-            // [0] = a
-            // [1] = 1
-            // [2] = 01x ('ok' relaced below)
-            var data = s.Trim().Replace("OK", "").Split(' ');
-
-            string command;
-            string id;
-            string responseValue;
+            // Expected format: "{command} {id} {OK|NG}{value}x"
+            // Example OK: "a 1 OK01x"  Example NG: "a 1 NG01x"
+            var data = s.Trim().Split(' ');
 
             if (data.Length < 3)
             {
-                Debug.LogVerbose(this, "Unable to parse message, not enough data in message: {0}", s);
+                this.LogVerbose("Unable to parse response, not enough data: {0}", s);
                 return;
             }
-            else
+
+            var command = data[0];
+            var id = data[1];
+            var statusAndValue = data[2];
+
+            // Check for NG response
+            if (statusAndValue.IndexOf("NG", StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                command = data[0];
-                id = data[1];
-                responseValue = data[2];
+                this.LogVerbose("NG response received for command '{0}': {1}", command, s);
+                PollAfterNgResponse(command);
+                return;
             }
 
+            // Strip OK prefix and trailing x delimiter
+            var responseValue = statusAndValue
+                .Replace("OK", "")
+                .TrimEnd('x');
+
             // Normalize both IDs to integers for comparison (handles "1" vs "01")
-            if (!NormalizeId(id).Equals(NormalizeId(Id)))
+            var normalizedReceived = NormalizeId(id);
+            var normalizedExpected = NormalizeId(Id);
+
+            if (!normalizedReceived.Equals(normalizedExpected))
             {
-                Debug.LogVerbose(this, "Device ID Mismatch - Expected: {0} (normalized: {1}), Received: {2} (normalized: {3}) - Discarding Response",
-                    Id, NormalizeId(Id), id, NormalizeId(id));
+                this.LogVerbose("Device ID Mismatch - Expected: {0} ({1}), Received: {2} ({3}) - Discarding",
+                    Id, normalizedExpected, id, normalizedReceived);
                 return;
             }
 
@@ -713,7 +709,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                     UpdatePowerFb(responseValue);
                     break;
                 case "b":
-                    UpdateInputFb(responseValue.Replace("x", ""));
+                    UpdateInputFb(responseValue);
                     break;
                 case "f":
                     UpdateVolumeFb(responseValue);

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -34,6 +34,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         private bool _isMuted;
         private bool _isSerialComm;
         private bool _isWarmingUp;
+        private bool _inputSwitchPending;
         private string _lastCommandPrefix;
         private int _lastVolumeSent;
         private bool _powerIsOn;
@@ -110,7 +111,15 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
                 if (_isWarmingUp)
                 {
-                    WarmupTimer = new CTimer(o => { IsWarmingUp = false; }, WarmupTime);
+                    WarmupTimer = new CTimer(o =>
+                    {
+                        IsWarmingUp = false;
+
+                        if (!_inputSwitchPending)
+                        {
+                            InputGet();
+                        }
+                    }, WarmupTime);
                 }
                 else if (WarmupTimer != null)
                 {
@@ -892,9 +901,12 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
             this.LogVerbose("ExecuteSwitch: preparing to execute {0}", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
 
+            _inputSwitchPending = true;
+
             if (PowerIsOn)
             {
                 action();
+                _inputSwitchPending = false;
             }
             else if (IsCoolingDown)
             {
@@ -910,6 +922,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
                     this.LogVerbose("ExecuteSwitch: Warmup complete. Executing {0}.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                     action();
+                    _inputSwitchPending = false;
                 });
             }
             else
@@ -922,6 +935,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
                     this.LogVerbose("ExecuteSwitch: Warmup complete. Executing {0}.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                     action();
+                    _inputSwitchPending = false;
                 });
             }
         }

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -95,55 +95,29 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 }
 
                 _powerIsOn = value;
-
-                if (_powerIsOn)
-                {
-                    if (CooldownTimer != null)
-                    {
-                        CooldownTimer.Stop();
-                        CooldownTimer.Dispose();
-                        CooldownTimer = null;
-                    }
-                    IsCoolingDown = false;
-
-                    IsWarmingUp = true;
-                    WarmupTimer = new CTimer(o =>
-                    {
-                        IsWarmingUp = false;
-                    }, WarmupTime);
-                }
-                else
-                {
-                    if (WarmupTimer != null)
-                    {
-                        WarmupTimer.Stop();
-                        WarmupTimer.Dispose();
-                        WarmupTimer = null;
-                    }
-                    IsWarmingUp = false;
-
-                    IsCoolingDown = true;
-                    CooldownTimer = new CTimer(o =>
-                    {
-                        IsCoolingDown = false;
-                    }, CooldownTime);
-                }
-
                 PowerIsOnFeedback.FireUpdate();
             }
         }
 
         public bool IsWarmingUp
         {
-            get
-            {
-                this.LogInformation("***** TESTING ***** IsWarmingUp get: {0}", _isWarmingUp);
-                return _isWarmingUp;
-            }
+            get { return _isWarmingUp; }
             set
             {
+                if (_isWarmingUp == value) return;
+
                 _isWarmingUp = value;
-                this.LogInformation("***** TESTING ***** IsWarmingUp set: {0}", _isWarmingUp);
+
+                if (_isWarmingUp)
+                {
+                    WarmupTimer = new CTimer(o => { IsWarmingUp = false; }, WarmupTime);
+                }
+                else if (WarmupTimer != null)
+                {
+                    WarmupTimer.Stop();
+                    WarmupTimer.Dispose();
+                    WarmupTimer = null;
+                }
 
                 IsWarmingUpFeedback.FireUpdate();
             }
@@ -151,15 +125,23 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         public bool IsCoolingDown
         {
-            get
-            {
-                this.LogInformation("***** TESTING ***** IsCoolingDown get: {0}", _isCoolingDown);
-                return _isCoolingDown;
-            }
+            get { return _isCoolingDown; }
             set
             {
+                if (_isCoolingDown == value) return;
+
                 _isCoolingDown = value;
-                this.LogInformation("***** TESTING ***** IsCoolingDown set: {0}", _isCoolingDown);
+
+                if (_isCoolingDown)
+                {
+                    CooldownTimer = new CTimer(o => { IsCoolingDown = false; }, CooldownTime);
+                }
+                else if (CooldownTimer != null)
+                {
+                    CooldownTimer.Stop();
+                    CooldownTimer.Dispose();
+                    CooldownTimer = null;
+                }
 
                 IsCoolingDownFeedback.FireUpdate();
             }
@@ -900,6 +882,12 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
             {
                 SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "1" : "01"));
             }
+
+            if (PowerIsOn)
+                return;
+
+            IsCoolingDown = false;
+            IsWarmingUp = true;
         }
 
         /// <summary>
@@ -908,6 +896,12 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         public override void PowerOff()
         {
             SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "0" : "00"));
+
+            if (!PowerIsOn)
+                return;
+
+            IsWarmingUp = false;
+            IsCoolingDown = true;
         }
 
         /// <summary>

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -121,20 +121,32 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         public bool IsWarmingUp
         {
-            get { return _isWarmingUp; }
+            get
+            {
+                this.LogVerbose("IsWarmingUp get: {0}", _isWarmingUp);
+                return _isWarmingUp;
+            }
             set
             {
                 _isWarmingUp = value;
+                this.LogVerbose("IsWarmingUp set: {0}", _isWarmingUp);
+
                 IsWarmingUpFeedback.FireUpdate();
             }
         }
 
         public bool IsCoolingDown
         {
-            get { return _isCoolingDown; }
+            get
+            {
+                this.LogVerbose("IsCoolingDown get: {0}", _isCoolingDown);
+                return _isCoolingDown;
+            }
             set
             {
                 _isCoolingDown = value;
+                this.LogVerbose("IsCoolingDown set: {0}", _isCoolingDown);
+
                 IsCoolingDownFeedback.FireUpdate();
             }
         }
@@ -379,6 +391,9 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
             trilist.SetSigTrueAction(joinMap.PowerOn.JoinNumber, PowerOn);
             PowerIsOnFeedback.LinkInputSig(trilist.BooleanInput[joinMap.PowerOn.JoinNumber]);
 
+            IsCoolingDownFeedback.LinkInputSig(trilist.BooleanInput[joinMap.IsCoolingDown.JoinNumber]);
+            IsWarmingUpFeedback.LinkInputSig(trilist.BooleanInput[joinMap.IsWarmingUp.JoinNumber]);
+
             // input (digital select, digital feedback, names)
             for (var i = 0; i < InputPorts.Count; i++)
             {
@@ -392,7 +407,12 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                     SetInput = inputIndex + 1;
                 });
 
-                trilist.StringInput[(ushort)(joinMap.InputNamesOffset.JoinNumber + inputIndex)].StringValue = string.IsNullOrEmpty(input.Key) ? string.Empty : input.Key;
+                var inputName = input.Key;
+                if (Inputs?.Items != null && input.FeedbackMatchObject is string fbMatch && Inputs.Items.TryGetValue(fbMatch, out var selectableItem))
+                {
+                    inputName = selectableItem.Name;
+                }
+                trilist.StringInput[(ushort)(joinMap.InputNamesOffset.JoinNumber + inputIndex)].StringValue = inputName ?? string.Empty;
 
                 if (InputFeedback != null && inputIndex < InputFeedback.Count)
                 {
@@ -558,7 +578,6 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 }
             };
             ApplyFriendlyNames(_config);
-
         }
         private void ApplyFriendlyNames(LgDisplayPropertiesConfig config)
         {

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -21,31 +21,31 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
     public class LgDisplayController : TwoWayDisplayBase, IBasicVolumeWithFeedback, ICommunicationMonitor,
         IInputHdmi1, IInputHdmi2, IInputHdmi3, IInputHdmi4, IInputDisplayPort1, IBridgeAdvanced, IHasInputs<string>, IBasicVideoMuteWithFeedback, IWarmingCooling
     {
-        GenericQueue ReceiveQueue;
+        GenericQueue receiveQueue;
         public const int InputPowerOn = 101;
         public const int InputPowerOff = 102;
         public static List<string> InputKeys = new List<string>();
         public List<BoolFeedback> InputFeedback;
         public IntFeedback InputNumberFeedback;
-        private RoutingInputPort _currentInputPort;
-        private List<bool> _inputFeedback;
-        private int _inputNumber;
-        private bool _isCoolingDown;
-        private bool _isMuted;
-        private bool _isSerialComm;
-        private bool _isWarmingUp;
-        private bool _inputSwitchPending;
-        private string _lastCommandPrefix;
-        private int _lastVolumeSent;
-        private bool _powerIsOn;
-        private bool _videoIsMuted;
-        private ActionIncrementer _volumeIncrementer;
-        private bool _volumeIsRamping;
-        private ushort _volumeLevelForSig;
-        private readonly bool _smallDisplay;
-        private readonly bool _overrideWol;
+        private RoutingInputPort currentInputPort;
+        private List<bool> inputFeedback;
+        private int inputNumber;
+        private bool isCoolingDown;
+        private bool isMuted;
+        private bool isSerialComm;
+        private bool isWarmingUp;
+        private bool inputSwitchPending;
+        private string lastCommandPrefix;
+        private int lastVolumeSent;
+        private bool powerIsOn;
+        private bool videoIsMuted;
+        private ActionIncrementer volumeIncrementer;
+        private bool volumeIsRamping;
+        private ushort volumeLevelForSig;
+        private readonly bool smallDisplay;
+        private readonly bool overrideWol;
         //private GenericUdpServer _woLServer;
-        private readonly LgDisplayPropertiesConfig _config;
+        private readonly LgDisplayPropertiesConfig config;
 
 
         public LgDisplayController(string key, string name, LgDisplayPropertiesConfig config, IBasicCommunication comms)
@@ -53,23 +53,23 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             Communication = comms;
 
-            ReceiveQueue = new GenericQueue(key + "-queue");
+            receiveQueue = new GenericQueue(key + "-queue");
 
-            _config = config;
+      this.config = config;
             var props = config;
             if (props == null)
             {
                 Debug.LogError(this, "Display configuration must be included");
                 return;
             }
-            _smallDisplay = props.SmallDisplay;
+            smallDisplay = props.SmallDisplay;
             Id = !string.IsNullOrEmpty(props.Id) ? props.Id : "01";
-            _upperLimit = props.volumeUpperLimit;
-            _lowerLimit = props.volumeLowerLimit;
-            _overrideWol = props.OverrideWol;
-            _pollIntervalMs = props.pollIntervalMs > 1999 ? props.pollIntervalMs : 10000;
-            _coolingTimeMs = props.coolingTimeMs > 0 ? props.coolingTimeMs : 10000;
-            _warmingTimeMs = props.warmingTimeMs > 0 ? props.warmingTimeMs : 8000;
+            upperLimit = props.volumeUpperLimit;
+            lowerLimit = props.volumeLowerLimit;
+            overrideWol = props.OverrideWol;
+            pollIntervalMs = props.pollIntervalMs > 1999 ? props.pollIntervalMs : 10000;
+            coolingTimeMs = props.coolingTimeMs > 0 ? props.coolingTimeMs : 10000;
+            warmingTimeMs = props.warmingTimeMs > 0 ? props.warmingTimeMs : 8000;
             //UdpSocketKey = props.udpSocketKey;
 
             InputNumberFeedback = new IntFeedback(() =>
@@ -87,35 +87,35 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         public bool PowerIsOn
         {
-            get { return _powerIsOn; }
+            get { return powerIsOn; }
             set
             {
-                if (_powerIsOn == value)
+                if (powerIsOn == value)
                 {
                     return;
                 }
 
-                _powerIsOn = value;
+                powerIsOn = value;
                 PowerIsOnFeedback.FireUpdate();
             }
         }
 
         public bool IsWarmingUp
         {
-            get { return _isWarmingUp; }
+            get { return isWarmingUp; }
             set
             {
-                if (_isWarmingUp == value) return;
+                if (isWarmingUp == value) return;
 
-                _isWarmingUp = value;
+                isWarmingUp = value;
 
-                if (_isWarmingUp)
+                if (isWarmingUp)
                 {
                     WarmupTimer = new CTimer(o =>
                     {
                         IsWarmingUp = false;
 
-                        if (!_inputSwitchPending)
+                        if (!inputSwitchPending)
                         {
                             InputGet();
                         }
@@ -134,14 +134,14 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         public bool IsCoolingDown
         {
-            get { return _isCoolingDown; }
+            get { return isCoolingDown; }
             set
             {
-                if (_isCoolingDown == value) return;
+                if (isCoolingDown == value) return;
 
-                _isCoolingDown = value;
+                isCoolingDown = value;
 
-                if (_isCoolingDown)
+                if (isCoolingDown)
                 {
                     CooldownTimer = new CTimer(o => { IsCoolingDown = false; }, CooldownTime);
                 }
@@ -158,37 +158,37 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         public bool IsMuted
         {
-            get { return _isMuted; }
+            get { return isMuted; }
             set
             {
-                _isMuted = value;
+                isMuted = value;
                 MuteFeedback.FireUpdate();
             }
         }
         public bool VideoIsMuted
         {
-            get { return _videoIsMuted; }
+            get { return videoIsMuted; }
             set
             {
-                _videoIsMuted = value;
+                videoIsMuted = value;
                 VideoMuteIsOn.FireUpdate();
             }
         }
 
-        private readonly int _lowerLimit;
-        private readonly int _upperLimit;
-        private readonly uint _coolingTimeMs;
-        private readonly uint _warmingTimeMs;
-        private readonly long _pollIntervalMs;
+        private readonly int lowerLimit;
+        private readonly int upperLimit;
+        private readonly uint coolingTimeMs;
+        private readonly uint warmingTimeMs;
+        private readonly long pollIntervalMs;
 
         public int InputNumber
         {
-            get { return _inputNumber; }
+            get { return inputNumber; }
             private set
             {
-                if (_inputNumber == value) return;
+                if (inputNumber == value) return;
 
-                _inputNumber = value;
+                inputNumber = value;
                 InputNumberFeedback.FireUpdate();
                 UpdateBooleanFeedback(value);
             }
@@ -213,7 +213,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         protected override Func<string> CurrentInputFeedbackFunc
         {
-            get { return () => _currentInputPort != null ? _currentInputPort.Key : string.Empty; }
+            get { return () => currentInputPort != null ? currentInputPort.Key : string.Empty; }
         }
 
         #region IBasicVolumeWithFeedback Members
@@ -236,14 +236,14 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         public void SetVolume(ushort level)
         {
             int scaled;
-            _lastVolumeSent = level;
+            lastVolumeSent = level;
             if (!ScaleVolume)
             {
                 scaled = (int)NumericalHelpers.Scale(level, 0, 65535, 0, 100);
             }
             else
             {
-                scaled = (int)NumericalHelpers.Scale(level, 0, 65535, _lowerLimit, _upperLimit);
+                scaled = (int)NumericalHelpers.Scale(level, 0, 65535, lowerLimit, upperLimit);
             }
 
             SendData(string.Format("kf {0} {1}", Id, scaled));
@@ -254,7 +254,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public void MuteOn()
         {
-            SendData(string.Format("ke {0} {1}", Id, _smallDisplay ? "0" : "00"));
+            SendData(string.Format("ke {0} {1}", Id, smallDisplay ? "0" : "00"));
         }
 
         /// <summary>
@@ -262,7 +262,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public void MuteOff()
         {
-            SendData(string.Format("ke {0} {1}", Id, _smallDisplay ? "1" : "01"));
+            SendData(string.Format("ke {0} {1}", Id, smallDisplay ? "1" : "01"));
         }
 
         /// <summary>
@@ -288,13 +288,13 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             if (pressRelease)
             {
-                _volumeIncrementer.StartDown();
-                _volumeIsRamping = true;
+                volumeIncrementer.StartDown();
+                volumeIsRamping = true;
             }
             else
             {
-                _volumeIsRamping = false;
-                _volumeIncrementer.Stop();
+                volumeIsRamping = false;
+                volumeIncrementer.Stop();
             }
         }
 
@@ -306,13 +306,13 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             if (pressRelease)
             {
-                _volumeIncrementer.StartUp();
-                _volumeIsRamping = true;
+                volumeIncrementer.StartUp();
+                volumeIsRamping = true;
             }
             else
             {
-                _volumeIsRamping = false;
-                _volumeIncrementer.Stop();
+                volumeIsRamping = false;
+                volumeIncrementer.Stop();
             }
         }
 
@@ -327,7 +327,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public void VideoMuteOn()
         {
-            SendData(string.Format("kd {0} {1}", Id, _smallDisplay ? "1" : "01"));
+            SendData(string.Format("kd {0} {1}", Id, smallDisplay ? "1" : "01"));
         }
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public void VideoMuteOff()
         {
-            SendData(string.Format("kd {0} {1}", Id, _smallDisplay ? "0" : "00"));
+            SendData(string.Format("kd {0} {1}", Id, smallDisplay ? "0" : "00"));
         }
 
         /// <summary>
@@ -480,13 +480,13 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         private void Init()
         {
-            WarmupTime = _warmingTimeMs > 0 ? _warmingTimeMs : 10000;
-            CooldownTime = _coolingTimeMs > 0 ? _coolingTimeMs : 8000;
+            WarmupTime = warmingTimeMs > 0 ? warmingTimeMs : 10000;
+            CooldownTime = coolingTimeMs > 0 ? coolingTimeMs : 8000;
 
-            _inputFeedback = new List<bool>();
+            inputFeedback = new List<bool>();
             InputFeedback = new List<BoolFeedback>();
 
-            if (_upperLimit != _lowerLimit && _upperLimit > _lowerLimit)
+            if (upperLimit != lowerLimit && upperLimit > lowerLimit)
             {
                 ScaleVolume = true;
             }
@@ -503,10 +503,10 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
             else
             {
                 // This instance uses RS-232 Control
-                _isSerialComm = true;
+                isSerialComm = true;
             }
 
-            var pollInterval = _pollIntervalMs > 0 ? _pollIntervalMs : 10000;
+            var pollInterval = pollIntervalMs > 0 ? pollIntervalMs : 10000;
             CommunicationMonitor = new GenericCommunicationMonitor(this, Communication, pollInterval, 180000, 300000,
                 StatusGet);
             CommunicationMonitor.StatusChange += CommunicationMonitor_StatusChange;
@@ -515,22 +515,22 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
             if (!ScaleVolume)
             {
-                _volumeIncrementer = new ActionIncrementer(655, 0, 65535, 800, 80,
+                volumeIncrementer = new ActionIncrementer(655, 0, 65535, 800, 80,
                     v => SetVolume((ushort)v),
-                    () => _lastVolumeSent);
+                    () => lastVolumeSent);
             }
             else
             {
-                var scaleUpper = NumericalHelpers.Scale(_upperLimit, 0, 100, 0, 65535);
-                var scaleLower = NumericalHelpers.Scale(_lowerLimit, 0, 100, 0, 65535);
+                var scaleUpper = NumericalHelpers.Scale(upperLimit, 0, 100, 0, 65535);
+                var scaleLower = NumericalHelpers.Scale(lowerLimit, 0, 100, 0, 65535);
 
-                _volumeIncrementer = new ActionIncrementer(655, (int)scaleLower, (int)scaleUpper, 800, 80,
+                volumeIncrementer = new ActionIncrementer(655, (int)scaleLower, (int)scaleUpper, 800, 80,
                     v => SetVolume((ushort)v),
-                    () => _lastVolumeSent);
+                    () => lastVolumeSent);
             }
 
             MuteFeedback = new BoolFeedback(() => IsMuted);
-            VolumeLevelFeedback = new IntFeedback(() => _volumeLevelForSig);
+            VolumeLevelFeedback = new IntFeedback(() => volumeLevelForSig);
             VideoMuteIsOn = new BoolFeedback(() => VideoIsMuted);
 
             AddRoutingInputPort(
@@ -549,14 +549,14 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 new RoutingInputPort(RoutingPortNames.DisplayPortIn, eRoutingSignalType.Audio | eRoutingSignalType.Video,
                     eRoutingPortConnectionType.DisplayPort, new Action(InputDisplayPort1), this), "c0");
 
-            _inputFeedback = new List<bool>(new bool[InputPorts.Count + 1]);
+            inputFeedback = new List<bool>(new bool[InputPorts.Count + 1]);
 
             // Initialize InputFeedback with a BoolFeedback for each input
             InputFeedback = new List<BoolFeedback>();
             for (int i = 0; i < InputPorts.Count; i++)
             {
                 int index = i + 1; // 1-based index to match InputNumber logic
-                InputFeedback.Add(new BoolFeedback(() => _inputFeedback[index]));
+                InputFeedback.Add(new BoolFeedback(() => inputFeedback[index]));
             }
 
             SetupInputs();
@@ -566,7 +566,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             Communication.Connect();
 
-            if (_isSerialComm || _overrideWol)
+            if (isSerialComm || overrideWol)
             {
                 CommunicationMonitor.Start();
             }
@@ -587,7 +587,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                     { "c0", new LgInput("c0", "DisplayPort", this) },
                 }
             };
-            ApplyFriendlyNames(_config);
+            ApplyFriendlyNames(config);
         }
         private void ApplyFriendlyNames(LgDisplayPropertiesConfig config)
         {
@@ -620,7 +620,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         private void PortGather_LineReceived(object sender, GenericCommMethodReceiveTextArgs args)
         {
-            ReceiveQueue.Enqueue(new ProcessStringMessage(args.Text, ProcessResponse));
+            receiveQueue.Enqueue(new ProcessStringMessage(args.Text, ProcessResponse));
         }
 
         private void PollAfterNgResponse(string ngCommand)
@@ -757,12 +757,12 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             var commandPrefix = s.Length >= 2 ? s.Substring(0, 2) : string.Empty;
 
-            if (_lastCommandPrefix == "kf" && commandPrefix != "kf")
+            if (lastCommandPrefix == "kf" && commandPrefix != "kf")
             {
                 CrestronEnvironment.Sleep(100);
             }
 
-            _lastCommandPrefix = commandPrefix;
+            lastCommandPrefix = commandPrefix;
 
             Communication.SendText(s + "\x0D");
         }
@@ -897,7 +897,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
             this.LogVerbose("ExecuteSwitch: preparing to execute {0}", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
 
-            _inputSwitchPending = true;
+            inputSwitchPending = true;
 
             if (PowerIsOn)
             {
@@ -907,7 +907,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 }
                 finally
                 {
-                    _inputSwitchPending = false;
+                    inputSwitchPending = false;
                 }
             }
             else if (IsCoolingDown)
@@ -929,7 +929,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                     }
                     finally
                     {
-                        _inputSwitchPending = false;
+                        inputSwitchPending = false;
                     }
                 });
             }
@@ -948,7 +948,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                     }
                     finally
                     {
-                        _inputSwitchPending = false;
+                        inputSwitchPending = false;
                     }
                 });
             }
@@ -1001,9 +1001,9 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         private void SendPowerOn()
         {
-            if (_isSerialComm || _overrideWol)
+            if (isSerialComm || overrideWol)
             {
-                SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "1" : "01"));
+                SendData(string.Format("ka {0} {1}", Id, smallDisplay ? "1" : "01"));
             }
 
             IsCoolingDown = false;
@@ -1012,7 +1012,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         private void SendPowerOff()
         {
-            SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "0" : "00"));
+            SendData(string.Format("ka {0} {1}", Id, smallDisplay ? "0" : "00"));
 
             IsWarmingUp = false;
             IsCoolingDown = true;
@@ -1051,9 +1051,9 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
             var normalizedInput = s.ToLower();
 
             var newInput = InputPorts.FirstOrDefault(i => i.FeedbackMatchObject.Equals(normalizedInput));
-            if (newInput != null && newInput != _currentInputPort)
+            if (newInput != null && newInput != currentInputPort)
             {
-                _currentInputPort = newInput;
+                currentInputPort = newInput;
                 CurrentInputFeedback.FireUpdate();
                 InputNumber = InputPorts.ToList().IndexOf(newInput) + 1;
             }
@@ -1120,18 +1120,18 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 }
                 else
                 {
-                    newVol = (ushort)NumericalHelpers.Scale(Convert.ToDouble(vol), _lowerLimit, _upperLimit, 0, 65535);
+                    newVol = (ushort)NumericalHelpers.Scale(Convert.ToDouble(vol), lowerLimit, upperLimit, 0, 65535);
                 }
-                if (!_volumeIsRamping)
+                if (!volumeIsRamping)
                 {
-                    _lastVolumeSent = newVol;
+                    lastVolumeSent = newVol;
                 }
 
-                if (newVol == _volumeLevelForSig)
+                if (newVol == volumeLevelForSig)
                 {
                     return;
                 }
-                _volumeLevelForSig = newVol;
+                volumeLevelForSig = newVol;
                 VolumeLevelFeedback.FireUpdate();
             }
             catch (Exception e)
@@ -1173,23 +1173,23 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             try
             {
-                if (data < 0 || data >= _inputFeedback.Count)
+                if (data < 0 || data >= inputFeedback.Count)
                 {
-                    Debug.LogVerbose(this, "Input index {0} out of range for _inputFeedback (size {1})", data, _inputFeedback.Count);
+                    Debug.LogVerbose(this, "Input index {0} out of range for _inputFeedback (size {1})", data, inputFeedback.Count);
                     return;
                 }
 
-                if (_inputFeedback[data])
+                if (inputFeedback[data])
                 {
                     return;
                 }
 
                 for (var i = 1; i < InputPorts.Count + 1; i++)
                 {
-                    _inputFeedback[i] = false;
+                    inputFeedback[i] = false;
                 }
 
-                _inputFeedback[data] = true;
+                inputFeedback[data] = true;
                 foreach (var item in InputFeedback)
                 {
                     var update = item;

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -901,24 +901,36 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
             if (PowerIsOn)
             {
-                action();
-                _inputSwitchPending = false;
+                try
+                {
+                    action();
+                }
+                finally
+                {
+                    _inputSwitchPending = false;
+                }
             }
             else if (IsCoolingDown)
             {
                 this.LogVerbose("ExecuteSwitch: Device is cooling down. Powering on and executing {0} after cooldown.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    CrestronEnvironment.Sleep((int)CooldownTime);
+                    try
+                    {
+                        CrestronEnvironment.Sleep((int)CooldownTime);
 
-                    this.LogVerbose("ExecuteSwitch: Cooldown complete. Powering on.");
-                    PowerOn();
+                        this.LogVerbose("ExecuteSwitch: Cooldown complete. Powering on.");
+                        PowerOn();
 
-                    CrestronEnvironment.Sleep((int)WarmupTime + 1000); // warmup time + 1000 for input switching delay                    
+                        CrestronEnvironment.Sleep((int)WarmupTime + 1000); // warmup time + 1000 for input switching delay                    
 
-                    this.LogVerbose("ExecuteSwitch: Warmup complete. Executing {0}.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
-                    action();
-                    _inputSwitchPending = false;
+                        this.LogVerbose("ExecuteSwitch: Warmup complete. Executing {0}.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
+                        action();
+                    }
+                    finally
+                    {
+                        _inputSwitchPending = false;
+                    }
                 });
             }
             else
@@ -927,11 +939,17 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                 PowerOn();
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    CrestronEnvironment.Sleep((int)WarmupTime + 1000); // warmup time + 1000 for input switching delay                    
+                    try
+                    {
+                        CrestronEnvironment.Sleep((int)WarmupTime + 1000); // warmup time + 1000 for input switching delay                    
 
-                    this.LogVerbose("ExecuteSwitch: Warmup complete. Executing {0}.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
-                    action();
-                    _inputSwitchPending = false;
+                        this.LogVerbose("ExecuteSwitch: Warmup complete. Executing {0}.", action?.Method.DeclaringType?.Name + "." + action?.Method.Name ?? "NULL");
+                        action();
+                    }
+                    finally
+                    {
+                        _inputSwitchPending = false;
+                    }
                 });
             }
         }

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -137,13 +137,13 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             get
             {
-                this.LogInformation("[TESTING] IsWarmingUp get: {0}", _isWarmingUp);
+                this.LogInformation("***** TESTING ***** IsWarmingUp get: {0}", _isWarmingUp);
                 return _isWarmingUp;
             }
             set
             {
                 _isWarmingUp = value;
-                this.LogInformation("[TESTING] IsWarmingUp set: {0}", _isWarmingUp);
+                this.LogInformation("***** TESTING ***** IsWarmingUp set: {0}", _isWarmingUp);
 
                 IsWarmingUpFeedback.FireUpdate();
             }
@@ -153,13 +153,13 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             get
             {
-                this.LogInformation("[TESTING] IsCoolingDown get: {0}", _isCoolingDown);
+                this.LogInformation("***** TESTING ***** IsCoolingDown get: {0}", _isCoolingDown);
                 return _isCoolingDown;
             }
             set
             {
                 _isCoolingDown = value;
-                this.LogInformation("[TESTING] IsCoolingDown set: {0}", _isCoolingDown);
+                this.LogInformation("***** TESTING ***** IsCoolingDown set: {0}", _isCoolingDown);
 
                 IsCoolingDownFeedback.FireUpdate();
             }
@@ -850,7 +850,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// <param name="selector"></param>
         public override void ExecuteSwitch(object selector)
         {
-            this.LogInformation("[TESTING] ExecuteSwitch called with selector of type {0}", selector?.GetType().Name ?? "NULL");
+            this.LogInformation("***** TESTING ***** ExecuteSwitch called with selector of type {0}", selector?.GetType().Name ?? "NULL");
 
             if (!(selector is Action action))
             {
@@ -859,32 +859,32 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
             if (PowerIsOn)
             {
-                this.LogInformation("[TESTING] Power is already on. Executing action.");
+                this.LogInformation("***** TESTING ***** Power is already on. Executing action.");
                 action();
             }
             else if (IsCoolingDown)
             {
-                this.LogInformation("[TESTING] Device is cooling down. Powering on and executing action after cooldown.");
+                this.LogInformation("***** TESTING ***** Device is cooling down. Powering on and executing action after cooldown.");
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    this.LogInformation("[TESTING] Cooldown complete. Powering on.");
+                    this.LogInformation("***** TESTING ***** Cooldown complete. Powering on.");
                     CrestronEnvironment.Sleep((int)CooldownTime);
                     PowerOn();
-                    this.LogInformation("[TESTING] Warmup time starting.");
+                    this.LogInformation("***** TESTING ***** Warmup time starting.");
                     CrestronEnvironment.Sleep((int)WarmupTime);
-                    this.LogInformation("[TESTING] Warmup complete. Executing action.");
+                    this.LogInformation("***** TESTING ***** Warmup complete. Executing action.");
                     action();
                 });
             }
             else
             {
-                this.LogInformation("[TESTING] Power is off. Powering on and executing action after warmup.");
+                this.LogInformation("***** TESTING ***** Power is off. Powering on and executing action after warmup.");
                 PowerOn();
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    this.LogInformation("[TESTING] Warmup time starting.");
+                    this.LogInformation("***** TESTING ***** Warmup time starting.");
                     CrestronEnvironment.Sleep((int)WarmupTime);
-                    this.LogInformation("[TESTING] Warmup complete. Executing action.");
+                    this.LogInformation("***** TESTING ***** Warmup complete. Executing action.");
                     action();
                 });
             }

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -35,6 +35,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         private bool isSerialComm;
         private bool isWarmingUp;
         private bool inputSwitchPending;
+        private bool powerOnPending;
         private string lastCommandPrefix;
         private int lastVolumeSent;
         private bool powerIsOn;
@@ -55,7 +56,7 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
             receiveQueue = new GenericQueue(key + "-queue");
 
-      this.config = config;
+            this.config = config;
             var props = config;
             if (props == null)
             {
@@ -919,8 +920,8 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
                     {
                         CrestronEnvironment.Sleep((int)CooldownTime);
 
-                        this.LogVerbose("ExecuteSwitch: Cooldown complete. Powering on.");
-                        PowerOn();
+                        this.LogVerbose("ExecuteSwitch: Cooldown complete. Sending power on.");
+                        SendPowerOn();
 
                         CrestronEnvironment.Sleep((int)WarmupTime + 1000); // warmup time + 1000 for input switching delay                    
 
@@ -962,14 +963,24 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         {
             if (IsCoolingDown)
             {
+                if (powerOnPending) return;
+
+                powerOnPending = true;
                 CrestronInvoke.BeginInvoke((o) =>
                 {
-                    this.LogVerbose("PowerOn: Device is cooling down. Powering on after cooldown completes.");
+                    try
+                    {
+                        this.LogVerbose("PowerOn: Device is cooling down. Powering on after cooldown completes.");
 
-                    CrestronEnvironment.Sleep((int)CooldownTime);
+                        CrestronEnvironment.Sleep((int)CooldownTime);
 
-                    this.LogVerbose("PowerOn: Cooldown complete. Powering on.");
-                    SendPowerOn();
+                        this.LogVerbose("PowerOn: Cooldown complete. Powering on.");
+                        SendPowerOn();
+                    }
+                    finally
+                    {
+                        powerOnPending = false;
+                    }
                 });
                 return;
             }
@@ -1001,21 +1012,33 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
 
         private void SendPowerOn()
         {
+            var powerCommandSent = false;
+
             if (isSerialComm || overrideWol)
             {
                 SendData(string.Format("ka {0} {1}", Id, smallDisplay ? "1" : "01"));
+                powerCommandSent = true;
             }
 
-            IsCoolingDown = false;
-            IsWarmingUp = true;
+            if (powerCommandSent && !PowerIsOn)
+            {
+                IsCoolingDown = false;
+                IsWarmingUp = true;
+            }
         }
 
         private void SendPowerOff()
         {
+            var wasPowerOn = PowerIsOn;
+
             SendData(string.Format("ka {0} {1}", Id, smallDisplay ? "0" : "00"));
 
             IsWarmingUp = false;
-            IsCoolingDown = true;
+
+            if (wasPowerOn)
+            {
+                IsCoolingDown = true;
+            }
         }
 
         /// <summary>

--- a/src/LgDisplayController.cs
+++ b/src/LgDisplayController.cs
@@ -878,16 +878,26 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public override void PowerOn()
         {
-            if (_isSerialComm || _overrideWol)
+            // if (PowerIsOn)
+            //     return;
+
+            this.LogInformation("***** TESTING ***** PowerOn called. IsWarmingUp: {0}, IsCoolingDown: {1}", IsWarmingUp, IsCoolingDown);
+
+            if (IsCoolingDown)
             {
-                SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "1" : "01"));
+                this.LogInformation("***** TESTING ***** Device is cooling down. Powering on after cooldown completes.");
+
+                CrestronInvoke.BeginInvoke((o) =>
+                {
+                    this.LogInformation("***** TESTING ***** Cooldown complete. Powering on.");
+                    CrestronEnvironment.Sleep((int)CooldownTime);
+                    this.LogInformation("***** TESTING ***** Powering on.");
+                    SendPowerOn();
+                });
+                return;
             }
 
-            if (PowerIsOn)
-                return;
-
-            IsCoolingDown = false;
-            IsWarmingUp = true;
+            SendPowerOn();
         }
 
         /// <summary>
@@ -895,10 +905,44 @@ namespace PepperDash.Essentials.Plugins.Lg.Display
         /// </summary>
         public override void PowerOff()
         {
-            SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "0" : "00"));
+            // if (!PowerIsOn)
+            //     return;
 
-            if (!PowerIsOn)
+            this.LogInformation("***** TESTING ***** PowerOff called. IsWarmingUp: {0}, IsCoolingDown: {1}", IsWarmingUp, IsCoolingDown);
+
+            if (IsWarmingUp)
+            {
+                CrestronInvoke.BeginInvoke((o) =>
+                {
+                    this.LogInformation("***** TESTING ***** Device is warming up. Powering off after warmup completes.");
+                    CrestronEnvironment.Sleep((int)WarmupTime);
+                    this.LogInformation("***** TESTING ***** Warmup complete. Powering off.");
+                    SendPowerOff();
+                });
                 return;
+            }
+
+            SendPowerOff();
+        }
+
+        private void SendPowerOn()
+        {
+            this.LogInformation("***** TESTING ***** SendPowerOn called.");
+
+            if (_isSerialComm || _overrideWol)
+            {
+                SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "1" : "01"));
+            }
+
+            IsCoolingDown = false;
+            IsWarmingUp = true;
+        }
+
+        private void SendPowerOff()
+        {
+            this.LogInformation("***** TESTING ***** SendPowerOff called.");
+            
+            SendData(string.Format("ka {0} {1}", Id, _smallDisplay ? "0" : "00"));
 
             IsWarmingUp = false;
             IsCoolingDown = true;


### PR DESCRIPTION
`_inputSwitchPending` was only reset on the success path after `action()` completed. Any exception thrown inside `action()` — or within the async `BeginInvoke` delegates for cooldown/warmup paths — left the flag stuck `true` indefinitely, suppressing the post-warmup `InputGet()` and leaving input feedback stale.

## Changes

- **`ExecuteSwitch` (`LgDisplayController.cs`):** Wrapped all three `action()` call sites in `try/finally` blocks to guarantee `_inputSwitchPending = false` regardless of outcome:
  - Synchronous `PowerIsOn` path
  - `BeginInvoke` delegate in the `IsCoolingDown` path
  - `BeginInvoke` delegate in the power-off (else) path

```csharp
// Before — flag left true if action() throws
action();
_inputSwitchPending = false;

// After — flag always cleared
try
{
    action();
}
finally
{
    _inputSwitchPending = false;
}
```